### PR TITLE
Enable debug logs for Amplitude

### DIFF
--- a/scripts/inject-amplitude.js
+++ b/scripts/inject-amplitude.js
@@ -18,7 +18,7 @@ if(AMPLITUDE_API_KEY){
         `;
 
     const amplitudeListenerScript = `<script type="module">
-        !function(){var e="${AMPLITUDE_API_KEY}";e&&(globalThis.amplitude.init(e),globalThis.amplitude.setOptOut(!1),globalThis.addEventListener("dydx:track",function(e){var t=e.detail.eventType,d=e.detail.eventData;globalThis.amplitude.track(t,d)}),globalThis.addEventListener("dydx:identify",function(e){var t=e.detail.property,d=e.detail.propertyValue;if("walletAddress"===t)globalThis.amplitude.setUserId(d);else{var i=new globalThis.amplitude.Identify;i.set(t,d),globalThis.amplitude.identify(i)}}),console.log("Amplitude enabled."))}();
+        !function(){var e="${AMPLITUDE_API_KEY}";e&&(globalThis.amplitude.init(e,null,{logLevel: globalThis.amplitude.Types.LogLevel.Debug}),globalThis.amplitude.setOptOut(!1),globalThis.addEventListener("dydx:track",function(e){var t=e.detail.eventType,d=e.detail.eventData;globalThis.amplitude.track(t,d)}),globalThis.addEventListener("dydx:identify",function(e){var t=e.detail.property,d=e.detail.propertyValue;if("walletAddress"===t)globalThis.amplitude.setUserId(d);else{var i=new globalThis.amplitude.Identify;i.set(t,d),globalThis.amplitude.identify(i)}}),console.log("Amplitude enabled."))}();
         </script>`;
 
     const injectedHtml = html.replace(


### PR DESCRIPTION
No events show in Amplitude on this page: https://app.amplitude.com/analytics/dydxopsdao/home .

As suggested there, we're adding debug logs according to these docs: https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/#configuration
so that we can see what's wrong.

This change is supposed to be temporary.