### PR TITLE
intercom US --> EU migration, temporary variable

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,6 +37,8 @@ Customize Intercom Messenger by adding logo and brand colors
 4. In your deploy scripts add `pnpm run build:inject-intercom` after your pnpm build / vite build command.
 5. If you are using with the Amplitude deployment scripts, your build command may look like the following: `pnpm build && pnpm run build:inject-amplitude && pnpm run build:inject-intercom`
 
+DOS is currently using a US workspace but is planning to migrate to the EU. We have introduced a temporary variable INTERCOM_API_BASE that will facilitate a smooth transition during the migration period. The plan after migration is to revert back to using a static definition with api_base set to 'https://api-iam.eu.intercom.io'.
+
 ### Smartbanner
 Smartbanner to show download links to iOS and/or Android native apps on mobile devices.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,7 +37,7 @@ Customize Intercom Messenger by adding logo and brand colors
 4. In your deploy scripts add `pnpm run build:inject-intercom` after your pnpm build / vite build command.
 5. If you are using with the Amplitude deployment scripts, your build command may look like the following: `pnpm build && pnpm run build:inject-amplitude && pnpm run build:inject-intercom`
 
-DOS is currently using a US workspace but is planning to migrate to the EU. We have introduced a temporary variable INTERCOM_API_BASE that will facilitate a smooth transition during the migration period. The plan after migration is to revert back to using a static definition with api_base set to 'https://api-iam.eu.intercom.io'.
+DOS is currently using a US workspace but is planning to migrate to the EU. We have introduced a temporary variable INTERCOM_API_BASE that will facilitate a smooth transition during the migration period. The plan after migration is to remove the variable and revert back to using a static definition with api_base set to 'https://api-iam.eu.intercom.io'.
 
 ### Smartbanner
 Smartbanner to show download links to iOS and/or Android native apps on mobile devices.

--- a/scripts/inject-intercom.js
+++ b/scripts/inject-intercom.js
@@ -27,7 +27,7 @@ async function inject(fileName) {
   <!-- Intercom -->
   <script>
     window.intercomSettings = {
-      api_base: 'https://api-iam.intercom.io',
+      api_base: ${INTERCOM_API_BASE}',
       app_id: '${INTERCOM_APP_ID}',
       custom_launcher_selector: '.custom_intercom',
       hide_default_launcher: true,

--- a/scripts/inject-intercom.js
+++ b/scripts/inject-intercom.js
@@ -27,7 +27,7 @@ async function inject(fileName) {
   <!-- Intercom -->
   <script>
     window.intercomSettings = {
-      api_base: ${INTERCOM_API_BASE}',
+      api_base: '${INTERCOM_API_BASE}',
       app_id: '${INTERCOM_APP_ID}',
       custom_launcher_selector: '.custom_intercom',
       hide_default_launcher: true,

--- a/scripts/inject-intercom.js
+++ b/scripts/inject-intercom.js
@@ -4,6 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const INTERCOM_APP_ID = process.env.INTERCOM_APP_ID;
+const INTERCOM_API_BASE = process.env.INTERCOM_API_BASE;
 
 const currentPath = fileURLToPath(import.meta.url);
 const projectRoot = path.dirname(currentPath);


### PR DESCRIPTION
# Context
DOS is currently using a US intercom workspace but is planning to migrate to the EU.

# What's Changed
* feat(intercom): introduce temporary variable for intercom EU migration testing

This commit introduces a temporary variable, INTERCOM_API_BASE, to facilitate the migration testing of Intercom from the US workspace to the EU workspace. Once the migration is complete, the plan is to revert back to using a static definition with api_base set to 'https://api-iam.eu.intercom.io'.