### PR TITLE
chore: Use new api proxies

### DIFF
--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -300,7 +300,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4dev.dydx.exchange"
          },
          "stakingValidators": [],
@@ -380,7 +380,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "http://dev3-faucet-lb-public-1644791410.us-east-2.elb.amazonaws.com"
          },
          "stakingValidators": [],
@@ -421,7 +421,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4dev4.dydx.exchange"
          },
          "stakingValidators": [],
@@ -637,7 +637,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [
@@ -681,7 +681,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -721,7 +721,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -762,7 +762,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -802,7 +802,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -843,7 +843,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -884,7 +884,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -924,10 +924,10 @@
                "https://dydx-ops-rpc.kingnodes.com"
             ],
             "0xsquid": "https://api.squidrouter.com",
-            "skip": "https://skip-proxy.infrastructure-34d.workers.dev",
+            "skip": "https://skip-proxy-web-mainnet.infrastructure-34d.workers.dev",
             "nobleValidator": "https://noble-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx"
+            "stakingAPR": "https://apybara-proxy-web-mainnet.infrastructure-34d.workers.dev/v0/protocols/dydx"
          },
          "ios": {
             "minimalVersion": "1.4.2",


### PR DESCRIPTION
Use the new API proxies with client-dedicated CORS setup.
See: https://github.com/dydxopsdao/api-proxies