### PR TITLE
feat: add security response headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
     {
       "source": "/portfolio(/?.*)",
@@ -23,6 +24,17 @@
     {
       "source": "/(.*)",
       "destination": "/entry-points/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds X-Frame-Options: DENY response header via vercel.json to block iframe embedding and address findings from a pen test and bug bounty report.

Tested on the preview deployment — header is present and iframe embedding is blocked (see screenshots). Let me know if this might affect anything unexpected.
![Screenshot 2025-05-21 at 15 32 29](https://github.com/user-attachments/assets/4b7609e0-e048-4a49-a74b-1ccfb542125b)
![Screenshot 2025-05-21 at 15 32 18](https://github.com/user-attachments/assets/d907e2d0-3e85-4ecb-be0d-2c12c9faace5)
